### PR TITLE
Point cluster-issuer app to main branch

### DIFF
--- a/apps/cert-manager/cert-manager-app.yaml
+++ b/apps/cert-manager/cert-manager-app.yaml
@@ -42,8 +42,8 @@ spec:
   project: infra
   source:
     path: manifests/cluster-issuer/
-    repoURL: https://github.com/zioproto/argocd-apps
-    targetRevision: refactory-2024
+    repoURL: https://github.com/ams0/argocd-apps
+    targetRevision: main
     directory:
       recurse: true
   syncPolicy:


### PR DESCRIPTION
Now that #3 is merged I can point the cluster issuer app to the main branch